### PR TITLE
Fix: setup correct service name for mariadb

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ git clone https://github.com/while-true-do/ansible-role-repo-mariadb.git while-t
 ```yaml
 # defaults/main.yml
 wtd_repo_mariadb_version: "10.2"
+wtd_repo_mariadb_service: "mariadb"
 
 wtd_repo_mariadb_supported_versions_centos: [ "5.5", "10.1", "10.2", "10.3" ]
 wtd_repo_mariadb_supported_versions_fedora: [ "10.2", "10.3" ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 wtd_repo_mariadb_version: "10.2"
+wtd_repo_mariadb_service: "mariadb"
 
 wtd_repo_mariadb_supported_versions_centos: [ "5.5", "10.1", "10.2", "10.3" ]
 wtd_repo_mariadb_supported_versions_fedora: [ "10.2", "10.3" ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,10 @@
 - name: "Include Add repository tasks for {{ ansible_distribution }}"
   include_tasks: "{{ ansible_distribution }}.yml"
 
+- name: "Include correct service name for repo MariaDB version: 5.5"
+  include_vars: service_name_5.5.yml
+  when: wtd_repo_mariadb_version == "5.5"
+
 - name: Add key for repository MariaDB
   rpm_key:
     state: present

--- a/vars/service_name_5.5.yml
+++ b/vars/service_name_5.5.yml
@@ -1,0 +1,2 @@
+---
+wtd_repo_mariadb_service: "mysql"


### PR DESCRIPTION
- switch service name to mysql on 5.5 repository packages

## Reference
 - Resolves: #3 
 - See also: https://github.com/while-true-do/ansible-role-mariadb/pull/5