### PR TITLE
Fix: Cleanup & supported Version removal

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 wtd_repo_mariadb_version: "10.2"
 
-wtd_repo_mariadb_supported_versions_centos: [ "5.5", "10.1", "10.2", "10.3" ]
+wtd_repo_mariadb_supported_versions_centos: [ "10.1", "10.2", "10.3" ]
 wtd_repo_mariadb_supported_versions_fedora: [ "10.2", "10.3" ]
-wtd_repo_mariadb_supported_versions_redhat: [ "5.5", "10.1", "10.2", "10.3" ]
+wtd_repo_mariadb_supported_versions_redhat: [ "10.1", "10.2", "10.3" ]

--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -12,10 +12,3 @@
     baseurl: "http://yum.mariadb.org/{{ wtd_repo_mariadb_version }}/{{ ansible_distribution.lower() }}{{ansible_distribution_major_version }}-amd64"
     gpgcheck: yes
     gpgkey: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-  register: wtd_repo_mariadb_added
-
-- name: Cleanup yum metadata if repository MariaDB was added
-  command: yum clean metadata
-  args:
-    warn: no
-  when: wtd_repo_mariadb_added.changed

--- a/tasks/Fedora.yml
+++ b/tasks/Fedora.yml
@@ -12,10 +12,3 @@
     baseurl: "http://yum.mariadb.org/{{ wtd_repo_mariadb_version }}/{{ ansible_distribution.lower() }}{{ansible_distribution_major_version }}-amd64"
     gpgcheck: yes
     gpgkey: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-  register: wtd_repo_mariadb_added
-
-- name: Refresh yum metadata if repository MariaDB was added
-  command: yum makecache fast
-  args:
-    warn: no
-  when: wtd_repo_mariadb_added.changed

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -12,10 +12,3 @@
     baseurl: "http://yum.mariadb.org/{{ wtd_repo_mariadb_version }}/rhel{{ansible_distribution_major_version }}-amd64"
     gpgcheck: yes
     gpgkey: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-  register: wtd_repo_mariadb_added
-
-- name: Refresh yum metadata if repository MariaDB was added
-  command: yum makecache fast
-  args:
-    warn: no
-  when: wtd_repo_mariadb_added.changed


### PR DESCRIPTION
  Fix: remove unnecessary cleanup tasks for yum
  Fix: support only needed mariadb versions

## Reference
 - Resolves: #5, #6 